### PR TITLE
Fix improper init layer obj

### DIFF
--- a/pyxc/core/layer.py
+++ b/pyxc/core/layer.py
@@ -116,7 +116,11 @@ class Layer(object):
         else:
             self.transformer: Type["TransformationBase"] = transformer
 
-        self.parent: None | Layer = parent  # Parent layer
+        self.parent: None | Layer = (
+            parent  # Just initialize the property. Will be set later.
+        )
+        if parent is not None:
+            self.set_parent(parent)
 
         # Load data
         self.container: Type["Container2D"] = dataloader(

--- a/test/core/test_layer.py
+++ b/test/core/test_layer.py
@@ -46,6 +46,17 @@ def test_layer_initialization(layer):
     assert isinstance(layer, Layer)
     assert not layer.is_transformed
 
+def test_layer_initialization_with_parent(layer):
+    L2_with_parent = Layer(
+        data=sample_data,
+        dataloader=ImageLoader,
+        transformer=Affine2D,
+        container=Container2D,
+        parent=layer,
+    )
+
+    assert L2_with_parent.parent == layer
+    assert L2_with_parent.transformer.parent == layer.transformer
 
 # Verify if the `Layer` object is successfully registered in `LAYERS`.
 def test_layer_registration(layer):


### PR DESCRIPTION
The layer was not properly initialized when the parent Layer was specified. Solved, test case added.