### PR TITLE
Fix wrong README.md content (XCorrelate -> PyXC)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# XCorrelate: 2-dimensional correlation library.
+# PyXC: 2-dimensional correlation library.
 
 [![Documentation Status](https://readthedocs.org/projects/pyxc/badge/?version=latest)](https://pyxc.readthedocs.io/en/latest/?badge=latest)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)


### PR DESCRIPTION
XCorrelate was a candidate for the library that was internally used. I forgot to update it to PyXC when this package was released.